### PR TITLE
[AST] security_org.apache.httpcomponents_httpclient_4.5.13  from 4.5.8 --> 4.5.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.salesforce.sconems</groupId>
         <artifactId>scone-ms-service-parent</artifactId>
-        <version>10.0.0</version>
+        <version>10.1.0</version>
         <relativePath/>
     </parent>
     <groupId>com.salesforce.rule.engine</groupId>
@@ -60,12 +60,12 @@
         <dependency>
             <groupId>org.drools</groupId>
             <artifactId>drools-core</artifactId>
-            <version>7.0.0.Final</version>
+            <version>7.25.0.Final</version>
         </dependency>
         <dependency>
             <groupId>org.kie</groupId>
             <artifactId>kie-spring</artifactId>
-            <version>7.0.0.Final</version>
+            <version>7.74.0.Final</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
@@ -75,7 +75,7 @@
         <dependency>
             <groupId>org.freemarker</groupId>
             <artifactId>freemarker</artifactId>
-            <version>2.3.28</version>
+            <version>2.3.30</version>
         </dependency><!-- 2.3.30-->
         <dependency>
             <groupId>org.mozilla</groupId>
@@ -85,12 +85,12 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.8.5</version>
+            <version>2.8.9</version>
         </dependency> <!-- 2.8.9 -->
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.5.8</version>
+            <version>4.5.13</version>
         </dependency><!-- 4.5.9-->
     </dependencies>
 </project>


### PR DESCRIPTION
The AST Team generated this pull request for fixing vulnerable packages or upgrade components in order to fix direct and transitive dependencies in this project's pom.xml manifest file.

  Following Vulnerabilities will be fixed 
  | Vulnerability | Score | URL |
|--------------|-------|-------------|
| CVE-2020-13956 | 5.3 | http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-13956 |


Please check the changes in this PR to ensure they won't cause issues with your project.