### PR TITLE
[AST] security_org.freemarker_freemarker_2.3.30  from 2.3.28 --> 2.3.30

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.salesforce.sconems</groupId>
         <artifactId>scone-ms-service-parent</artifactId>
-        <version>10.0.0</version>
+        <version>10.1.0</version>
         <relativePath/>
     </parent>
     <groupId>com.salesforce.rule.engine</groupId>
@@ -60,12 +60,12 @@
         <dependency>
             <groupId>org.drools</groupId>
             <artifactId>drools-core</artifactId>
-            <version>7.0.0.Final</version>
+            <version>7.25.0.Final</version>
         </dependency>
         <dependency>
             <groupId>org.kie</groupId>
             <artifactId>kie-spring</artifactId>
-            <version>7.0.0.Final</version>
+            <version>7.74.0.Final</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
@@ -75,7 +75,7 @@
         <dependency>
             <groupId>org.freemarker</groupId>
             <artifactId>freemarker</artifactId>
-            <version>2.3.28</version>
+            <version>2.3.30</version>
         </dependency><!-- 2.3.30-->
         <dependency>
             <groupId>org.mozilla</groupId>


### PR DESCRIPTION
The AST Team generated this pull request for fixing vulnerable packages or upgrade components in order to fix direct and transitive dependencies in this project's pom.xml manifest file.

  Following Vulnerabilities will be fixed 
  | Vulnerability | Score | URL |
|--------------|-------|-------------|
| sonatype-2019-0870 | 7.7 | http://localhost:8070/ui/links/vln/sonatype-2019-0870 |


Please check the changes in this PR to ensure they won't cause issues with your project.