### PR TITLE
[AST] upgrade_library_openjdk_46_89  from _46 --> 89

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/openjdk:46
+FROM docker.io/library/openjdk:89
 
 #LABEL maintainer ast-dev@salesforce.com
 LABEL pipeline_args=$pipeline_args


### PR DESCRIPTION
The AST Team generated this pull request for fixing vulnerable packages or upgrade components in order to fix direct and transitive dependencies in this project's dockerfile manifest file.

  
Please check the changes in this PR to ensure they won't cause issues with your project.